### PR TITLE
fix obj_grabbed

### DIFF
--- a/frappy_HZB/robo_my.py
+++ b/frappy_HZB/robo_my.py
@@ -186,7 +186,8 @@ class Robot(HasIO,Drivable):
     obj_grabbed = Parameter("Boolean if object has been detected in gripper",
                            datatype = BoolType(),
                            visibility = 'expert', #issue:closing raises KeyError: True when grabbing (closing gripper)
-                           default = False)
+                           default = False,
+                           readonly = True)
     
     
     def initModule(self):
@@ -355,7 +356,10 @@ class Robot(HasIO,Drivable):
         async def run():
             await self.gripper.connect()
             await self.gripper.move_and_wait_for_pos(255, 100, 100)
-            self.write_obj_grabbed(self, await self.gripper._get_var('OBJ') == 3) #muss noch überprüft werden welche zahl grabbed bedeutet
+            
+            OBJ_status = await self.gripper._get_var('OBJ')             
+            self.obj_grabbed = OBJ_status == 1 or OBJ_status == 2
+
             await self.gripper.disconnect()
         return asyncio.run(run())
 


### PR DESCRIPTION
die `write_obj_grabbed` methode braucht man eigentlich nur wenn man einen Paramter property `readonly == False` hat. 
den Parameter soll man aber eigentlich nur lesen dürfen als client, deshalb hab ich die methode mal weg gemacht, und explizit `readonly == True` gesetzt. 

Die Fehlermeldung mit dem `KeyError` kam wegen deinem methoden aufruf:

```python
self.write_obj_grabbed(self, await self.gripper._get_var('OBJ') == 3)
```

du hattest bei der write methode ausversehen noch `self` als erstes argument übergeben. 




 